### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,8 @@
+{% extends template.self %}
+
+{% block javascript %}
+    {{ super() }}
+    <div style="display:{% if config.pluginsConfig.cnzz.visible %}inherit{% else %}none{% endif %}">
+        <script src="http://s95.cnzz.com/z_stat.php?id={{ config.pluginsConfig.cnzz.siteid }}&web_id={{ config.pluginsConfig.cnzz.siteid }}" language="JavaScript"></script>
+    </div>
+{% endblock %}

--- a/book/plugin.js
+++ b/book/plugin.js
@@ -1,5 +1,0 @@
-require(["gitbook"], function(gitbook) {
-    gitbook.events.bind("start", function(e, config) {
-        config.cnzz = config.cnzz || {};
-    });
-});

--- a/index.js
+++ b/index.js
@@ -1,8 +1,0 @@
-module.exports = {
-    book: {
-        assets: "./book",
-        js: [
-            "plugin.js"
-        ]
-    }
-};

--- a/index.js
+++ b/index.js
@@ -3,24 +3,6 @@ module.exports = {
         assets: "./book",
         js: [
             "plugin.js"
-        ],
-        html: {
-            "body:end": function() {
-                var visible = this.options.pluginsConfig.cnzz.visible;
-                var style = this.options.pluginsConfig.cnzz.style;
-                var siteid = this.options.pluginsConfig.cnzz.siteid;
-
-                console.log("visible:" + visible + ", style:" + style + ", siteid:" + siteid);
-
-                var stat = "<script src='http://s95.cnzz.com/z_stat.php?id="
-                    + siteid + "&web_id=" + siteid + "' language='JavaScript'></script>";
-
-                if (visible) {
-                    return stat;
-                } else {
-                    return "<div style='display:none'>" + stat + "</div>";
-                }
-            }
-        }
+        ]
     }
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
     "name": "gitbook-plugin-cnzz",
     "version": "0.0.1",
     "description": "CNZZ Analytics tracking for your gitbook.",
-    "main": "index.js",
     "repository": {
         "type": "git",
         "url": "https://github.com/linfuyan/gitbook-plugin-cnzz"


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, the hooks used for this plugin will not be supported, since we are relying a lot more on the templating system to extend the books HTML.

The proposed PR has been tested with the new version and directly includes the script using GitBook 3 templating.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

If you release a new version, please upgrade the gitbook engine in `package.json`:

``` JSON
"engines": {
    "gitbook": ">=3.0.0-pre.0"
}
```

Kind regards,
Johan
